### PR TITLE
SBCOSS-466: Userorg service  - create Github actions to publish docker image to GHCR

### DIFF
--- a/.github/BUILD.md
+++ b/.github/BUILD.md
@@ -1,0 +1,74 @@
+# GitHub Action: Build and Deploy
+
+## Overview
+This GitHub Action automates the build and deployment process for the UserOrg service. It builds the project, runs tests, packages the application, and pushes a Docker image to GitHub Container Registry (GHCR).
+
+## Usage
+The action will automatically build and deploy your service whenever a new tag is pushed.
+
+## Steps
+
+1. **Set up JDK 11**
+   - Configures the environment with JDK 11 using the `actions/setup-java` action with Temurin distribution.
+
+2. **Checkout code**
+   - Checks out the repository code with full commit history.
+
+3. **Cache Maven packages**
+   - Caches Maven dependencies to speed up subsequent builds.
+
+4. **Build and run test cases**
+   ```bash
+   mvn clean install
+   ```
+
+5. **Package build artifact**
+   - Packages the application using Play Framework's `dist` goal.
+   ```bash
+   mvn -f controller/pom.xml play2:dist
+   ```
+
+6. **Upload artifact**
+   - Uploads the packaged application as a GitHub Actions artifact named `userorg-service-dist`.
+
+7. **Extract image tag details**
+   - Prepares Docker image name and tags based on the repository name and reference.
+
+8. **Log in to GitHub Container Registry**
+   - Authenticates to GHCR using the provided GitHub token.
+
+9. **Build and push Docker image**
+   - Builds the Docker image using the provided Dockerfile and pushes it to GHCR with the appropriate tags.
+
+## Environment Variables
+- `REGISTRY`: The GitHub Container Registry URL (ghcr.io)
+- `IMAGE_NAME`: Auto-generated based on the repository name (e.g., ghcr.io/username/repo)
+- `IMAGE_TAG`: Auto-generated based on the git reference (branch name or tag)
+
+## Permissions
+This workflow requires the following permissions:
+- `contents: read` - To read the repository contents
+- `packages: write` - To push Docker images to GitHub Container Registry
+
+## How to Use the Docker Image
+
+1. **Pull the Docker Image**:
+   ```bash
+   docker pull ghcr.io/<repository-name>:<tag>
+   ```
+   Replace `<repository-name>` and `<tag>` with the appropriate values.
+
+2. **Run the Docker Container**:
+   ```bash
+   docker run -d -p <host-port>:9000 ghcr.io/<repository-name>:<tag>
+   ```
+   Replace `<host-port>` with your desired port numbers.
+
+3. **Access the Application**:
+   Once the container is running, you can access the application at `http://localhost:<host-port>`.
+
+## Notes
+- The workflow is configured to use Ubuntu latest runner.
+- Maven dependencies are cached to improve build performance.
+- The Docker image is built using the Dockerfile in the repository root.
+- The workflow automatically handles both branch-based and tag-based deployments.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,88 @@
+name: Build and Deploy
+
+# Trigger this workflow whenever there is a new tag push
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  ghcr-build-and-deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read         # Read access to repository contents
+      packages: write        # Permission to write to GitHub Packages (GHCR)
+
+# Define container registry to be GitHub Container Registry and store it as an env
+    env:
+      REGISTRY: ghcr.io      
+
+    steps:
+      # Set up Java Development Kit (JDK) version 11 using Temurin distribution
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      # Checkout the repository code with full history (fetch-depth: 0)
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Cache Maven dependencies to speed up subsequent builds
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Build the project and run test cases
+      - name: Build and run test cases
+        run: | 
+          mvn clean install
+
+      # Package the build artifact using Play Framework's `dist` goal
+      - name: Package build artifact (Play dist)
+        run: mvn -f controller/pom.xml play2:dist
+
+      # Upload the build artifact as an artifact to GitHub Actions
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: userorg-service-dist
+          path: |
+            controller/target/userorg-service-*-dist.zip
+
+      # Extract repository and tag info to form image name and tag
+      - name: Extract image tag details
+        id: image_vars
+        run: |
+          REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
+          IMAGE_TAG=${TAG_LOWER}
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      # Log in to GitHub Container Registry using the GitHub Actions token
+      - name: Log in to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build and push Docker image to GitHub Container Registry (GHCR)
+      - name: Build and push Docker image to GHCR
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to the `userorg-service` repository.

**Build and Deploy (`build.yml`):**  
Triggers when a Git tag is pushed.  
Builds the project, packages the artifact, builds a Docker image, and pushes it to GitHub Container Registry (GHCR).

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Create a GitHub Action workflow to automate the build, test, packaging, and deployment of the UserOrg service Docker image to GitHub Container Registry (GHCR) upon a new tag push.

### Why are these changes being made?

This change introduces automation to streamline the deployment process, reducing manual steps and errors. Utilizing a GitHub Action enhances the CI/CD pipeline, ensuring that docker images are consistently built and published, improving reliability and efficiency in deployment workflows. The approach allows for easy integration into existing infrastructures and supports modern development practices via automated containerization.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->