### PR TITLE
To fix the docker image name which is pushed to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,11 +64,13 @@ jobs:
         id: image_vars
         run: |
           REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          SHORT_SHA=$(git rev-parse HEAD | cut -c1-7)
           TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
           IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
-          IMAGE_TAG=${TAG_LOWER}
+          IMAGE_TAG=${TAG_LOWER}_${SHORT_SHA}_${GITHUB_RUN_NUMBER}
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
 
       # Log in to GitHub Container Registry using the GitHub Actions token
       - name: Log in to GitHub Container Registry (GHCR)


### PR DESCRIPTION
This PR fixes the docker image tag name where the commit SHA was not being added previously.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the Docker image tagging process to include a short commit SHA and run number in the image tag when pushing to GitHub Container Registry (GHCR).

### Why are these changes being made?

The change ensures uniqueness and traceability of Docker image tags by incorporating specific identifiers, such as a short commit SHA and the GitHub Actions run number, resulting in easier tracking and identification of images for debugging and versioning purposes. This approach enhances the CI/CD process by reducing the risk of overwriting images and aids in troubleshooting by offering contextual information directly within the tag.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->