### PR TITLE
Issue #SBCOSS-00: Downgrade Elasticsearch client to 7.10.2 for open source compliance

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -173,7 +173,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.1</version>
+			<version>4.5.13</version>
 		</dependency>
 
 		<dependency>

--- a/core/es-utils/pom.xml
+++ b/core/es-utils/pom.xml
@@ -29,7 +29,7 @@
 	    <dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>elasticsearch-rest-high-level-client</artifactId>
-			<version>7.17.13</version>
+			<version>7.10.2</version>
         </dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/core/notification-utils/pom.xml
+++ b/core/notification-utils/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/core/platform-common/pom.xml
+++ b/core/platform-common/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.5.2</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
## Summary
This PR downgrades the Elasticsearch client dependency from version 7.17.13 to 7.10.2 and updates HTTP client dependencies to resolve conflicts while maintaining Apache 2.0 open source licensing compliance.

## Changes
- Downgraded `elasticsearch-rest-high-level-client` from `7.17.13` to `7.10.2` in `core/es-utils/pom.xml`
- Updated `httpclient` from `4.5.1` to `4.5.13` in `controller/pom.xml`
- Updated `httpclient` from `4.5.2` to `4.5.13` in `core/notification-utils/pom.xml`
- Updated `httpmime` from `4.5.2` to `4.5.13` in `core/platform-common/pom.xml`

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Downgrade the Elasticsearch client to version 7.10.2 for open source compliance and update the httpclient version to 4.5.13 across several `pom.xml` files.

### Why are these changes being made?

These changes ensure compliance with open source licensing by reverting to a compatible version of Elasticsearch and align httpclient dependencies across modules to a more recent, stable release, potentially fixing issues with varying versions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->