### PR TITLE
fix: Update CLOUD_STORE_VERSION to 1.4.8.1 in pom.xml

### DIFF
--- a/core/platform-common/pom.xml
+++ b/core/platform-common/pom.xml
@@ -26,7 +26,7 @@
         <jackson.version>2.14.3</jackson.version>
         <CLOUD_STORE_GROUP_ID>org.sunbird</CLOUD_STORE_GROUP_ID>
         <CLOUD_STORE_ARTIFACT_ID>cloud-store-sdk_2.13</CLOUD_STORE_ARTIFACT_ID>
-        <CLOUD_STORE_VERSION>1.4.8</CLOUD_STORE_VERSION>
+        <CLOUD_STORE_VERSION>1.4.8.1</CLOUD_STORE_VERSION>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the `core/platform-common/pom.xml` file, upgrading the version of the `cloud-store-sdk_2.13` dependency from `1.4.8` to `1.4.8.1`.