### PR TITLE
Upgrade kafka-clients dependency for Kafka 4.x compatibility

### DIFF
--- a/core/platform-common/pom.xml
+++ b/core/platform-common/pom.xml
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.4.0</version>
+            <version>3.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
## Summary

This PR upgrades the kafka-clients dependency to a version compatible with Kafka 4.x.